### PR TITLE
Don't check default cloudfront cert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ pyopenssl==0.13.0
 termcolor==1.1.0
 sure==1.2.12
 coverage==3.7.1
--e git+ssh://git@github.com/chrishenry/moto@elb-scheme#egg=moto
+-e git+https://git@github.com/chrishenry/moto@elb-scheme#egg=moto

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 clint==0.3.4
-boto==2.36.0
+boto3==1.2.2
 cement==2.4.0
 tabulate==0.7.3
 mock==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ unittest2==0.5.1
 pygerduty==0.28
 pyopenssl==0.13.0
 termcolor==1.1.0
-moto==0.4.4
 sure==1.2.12
 coverage==3.7.1
+-e git+ssh://git@github.com/chrishenry/moto@elb-scheme#egg=moto

--- a/tests/unit/test_certificate.py
+++ b/tests/unit/test_certificate.py
@@ -1,0 +1,32 @@
+# This file is part of Certifier.
+# Copyright 2015, Behance Ops.
+
+"""Tests for the the Certificate service class"""
+
+import os
+import sys
+import time
+import ConfigParser
+from tests.unit import CertifierTestCase
+import sure
+import mock
+from mock import patch
+from mock import Mock
+from nose.plugins.attrib import attr
+
+import boto.ec2.elb as elb
+
+
+from moto import mock_elb
+
+from certifier.elb import *
+from certifier.certificate import *
+
+class CertificateTestCase(CertifierTestCase):
+
+    def setUp(self):
+        super(CertificateTestCase, self).setUp()
+
+    def test_pyopenssl_callback(self):
+
+        pyopenssl_check_callback(None, None, None, None, None).should.be.ok

--- a/tests/unit/test_certificate.py
+++ b/tests/unit/test_certificate.py
@@ -15,8 +15,6 @@ from mock import Mock
 from nose.plugins.attrib import attr
 
 import boto.ec2.elb as elb
-
-
 from moto import mock_elb
 
 from certifier.elb import *
@@ -30,3 +28,7 @@ class CertificateTestCase(CertifierTestCase):
     def test_pyopenssl_callback(self):
 
         pyopenssl_check_callback(None, None, None, None, None).should.be.ok
+
+    def test_get_expiry(self):
+        get_expiry('www.google.com').should.be.a('datetime.datetime')
+

--- a/tests/unit/test_elb.py
+++ b/tests/unit/test_elb.py
@@ -61,16 +61,20 @@ class ElbTestCase(CertifierTestCase):
 
         self.create_elb()
         self.create_elb(scheme='internal')
+        self.create_elb(scheme='poopy-scheme', include_https=False)
 
         certify_elbs(self.creds)
 
-    def create_elb(self, scheme='internet-facing'):
+    def create_elb(self, scheme='internet-facing', include_https=True):
 
         name = self.random_name()
 
         conn = elb.connect_to_region('us-east-1')
 
         zones = ['us-east-1a', 'us-east-1b']
-        ports = [(80, 80, 'http'), (443, 80, 'https', 'arn:aws:iam::1234567890123:server-certificate/my.nifty.cert.net')]
+        ports = [(80, 80, 'http')]
+        if include_https:
+            ports.append((443, 80, 'https', 'arn:aws:iam::1234567890123:server-certificate/my.nifty.cert.net'))
+
         lb = conn.create_load_balancer(name, zones, ports, scheme=scheme)
 


### PR DESCRIPTION
This PR will cause certifier to __not__ check the default cloudfront cert. Since no one controls the cloudfront cert but AWS, alerting or reporting on it is not actionable.